### PR TITLE
catch the error returned by add_repo_status

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -185,7 +185,11 @@ pub fn get_status_table(config: config::Config) -> Result<(Vec<Table>, Vec<Strin
                 }
             };
 
-            add_repo_status(&mut table, &repo.name, &repo_handle, repo.worktree_setup)?;
+            if let Err(err) =
+                add_repo_status(&mut table, &repo.name, &repo_handle, repo.worktree_setup)
+            {
+                errors.push(format!("{}: Couldn't add repo status: {}", &repo.name, err));
+            }
         }
 
         tables.push(table);


### PR DESCRIPTION
Hi, thanks for the tool ! I'm playing around with it to see if I can use it and I encountered a small issue:

If `add_repo_status` returns an error it will eventually be printed to the user but there won't be any repository information:

    [✘] Error getting status: No branch checked out

This patch catches the error earlier so we can print the repository name:

    [✘] Error: freebsd-src: Couldn't add repo status: No branch checked out

(ideally `repos status` wouldn't fail if there's no branch checked out but that's another story).