### PR TITLE
feat: Return an error if the remote type cannot be detected

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,2 +1,3 @@
 nonnominandus
 Maximilian Volk
+Baptiste (@BapRx)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,12 +63,13 @@ fn find_repos(root: &Path) -> Result<Option<(Vec<repo::Repo>, Vec<String>, bool)
                             let name = remote.name();
                             let url = remote.url();
                             let remote_type = match repo::detect_remote_type(&url) {
-                                Some(t) => t,
-                                None => {
+                                Ok(t) => t,
+                                Err(e) => {
                                     warnings.push(format!(
-                                        "{}: Could not detect remote type of \"{}\"",
+                                        "{}: Could not detect remote type of \"{}\". Reason: {}",
                                         &path::path_as_string(&path),
-                                        &url
+                                        &url,
+                                        e
                                     ));
                                     continue;
                                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ fn find_repos(root: &Path) -> Result<Option<(Vec<repo::Repo>, Vec<String>, bool)
                                 Ok(t) => t,
                                 Err(e) => {
                                     warnings.push(format!(
-                                        "{}: Could not detect remote type of \"{}\". Reason: {}",
+                                        "{}: Could not handle URL {}. Reason: {}",
                                         &path::path_as_string(&path),
                                         &url,
                                         e


### PR DESCRIPTION
Here's what we discussed in #52, currently the behavior is to skip the remote if the type cannot be detected. That results in possibly empty remote in the config. I don't know if that is an issue or not.

```bash
❯ grm repos find local -f yaml ~/work/customer
trees:
- root: ~/work/customer
  repos:
  - name: kubernetes-manifests
    worktree_setup: false
    remotes: []
  - name: gcp-run
    worktree_setup: false
    remotes: []
[!] /home/baptiste/work/customer/kubernetes-manifests: Could not detect remote type of "http://gitlab.local/devops/kubernetes-manifests.git". Reason: Remotes using HTTP protocol are not supported
[!] /home/baptiste/work/customer/gcp-run: Could not detect remote type of "http://gitlab.local/devops/gcp-run.git". Reason: Remotes using HTTP protocol are not supported
```
