### PR TITLE
Add Nix build and packaging support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+result

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,3 +1,4 @@
 nonnominandus
 Maximilian Volk
 Baptiste (@BapRx)
+Sirio Balmelli

--- a/docs/src/developing.md
+++ b/docs/src/developing.md
@@ -52,3 +52,59 @@ mvdan.cc/sh/v3/cmd/shfmt@latest`, depending on your go build environment.
 
 For details about rustup and the toolchains, see [the installation
 section](./installation.md).
+
+## Development Environment with [Nix](https://nixos.org)
+
+Enter a development shell with all tools and dependencies:
+
+```bash
+$ nix develop
+```
+
+From within the nix shell:
+
+```bash
+$ just [TARGET]
+```
+
+or
+
+```bash
+$ cargo build
+```
+
+Update toolchain and dependencies:
+
+```bash
+$ nix flake update
+```
+
+Build:
+
+```bash
+$ nix build
+```
+
+Run:
+
+```bash
+$ nix run . -- [ARGUMENTS]
+```
+
+Find more documentation about Nix Flakes here: https://nixos.wiki/wiki/Flakes
+
+### Caveats
+
+The current Nix environment does not source:
+
+- aarch64-unknown-linux-musl
+- x86_64-unknown-linux-musl
+- docker and related tools
+
+If interest develops this can be added.
+
+### Developing Nix
+
+The crate is built using [Crane](https://github.com/ipetkov/crane).
+
+Format code with [alejandra](https://github.com/kamadorueda/alejandra).

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -8,7 +8,7 @@ installed.
 
 Make sure that the stable toolchain is installed:
 
-```
+```bash
 $ rustup toolchain install stable
 ```
 
@@ -46,12 +46,12 @@ need `musl` and a few other build dependencies installed installed:
 
 The, add the musl target via `rustup`:
 
-```
+```bash
 $ rustup target add x86_64-unknown-linux-musl
 ```
 
 Then, use a modified build command to get a statically linked binary:
 
-```
+```bash
 $ cargo install git-repo-manager --target x86_64-unknown-linux-musl --features=static-build
 ```

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -55,3 +55,42 @@ Then, use a modified build command to get a statically linked binary:
 ```bash
 $ cargo install git-repo-manager --target x86_64-unknown-linux-musl --features=static-build
 ```
+
+## [Nix](https://nixos.org/)
+
+Run from github without downloading:
+
+```bash
+$ nix run github:hakoerber/git-repo-manager/develop -- --version
+git-repo-manager 0.7.15
+```
+
+Run from local source directory:
+
+```bash
+$ nix run . -- --version
+git-repo-manager 0.7.15
+```
+
+Integrate into a [Nix Flake](https://nixos.wiki/wiki/Flakes):
+
+```nix
+{
+  inputs = {
+    ...
+    git-repo-manager = {
+      url = "github:hakoerber/git-repo-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+  };
+
+  outputs = {
+    ...
+    pkgs = import inputs.nixpkgs {
+        ...
+        overlays = [ inputs.git-repo-manager.overlays.git-repo-manager ];
+    };
+  };
+}
+```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,106 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1706473964,
+        "narHash": "sha256-Fq6xleee/TsX6NbtoRuI96bBuDHMU57PrcK9z1QEKbk=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "c798790eabec3e3da48190ae3698ac227aab770c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1706487304,
+        "narHash": "sha256-LE8lVX28MV2jWJsidW13D2qrHU/RUUONendL2Q/WlJg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "90f456026d284c22b3e3497be980b2e47d0b28ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1706580650,
+        "narHash": "sha256-e6q4Pn1dp3NoQJdMYdyNdDHU5IRBW9i3bHSJ3jThEL0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "39e20b3c02caa91c9970beef325a04975d83d77f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,107 @@
+{
+  description = "git-repo-manager";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    crane,
+    rust-overlay,
+  }:
+    {
+      overlays = {
+        git-repo-manager = final: prev: {
+          git-repo-manager = self.packages.${prev.stdenv.system}.default;
+        };
+      };
+    }
+    // flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs =
+          import nixpkgs
+          {
+            inherit system;
+            overlays = [
+              rust-overlay.overlays.default
+            ];
+          };
+
+        rustToolchain = pkgs.rust-bin.stable.latest.default;
+        craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+        environment = with pkgs; {
+          pname = "grm"; # otherwise `nix run` looks for git-repo-manager
+          src = craneLib.cleanCargoSource (craneLib.path ./.);
+          buildInputs =
+            [
+              # tools
+              pkg-config
+              rustToolchain
+              # deps
+              git
+              openssl
+              openssl.dev
+              zlib
+              zlib.dev
+            ]
+            ++ lib.optional stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+              CoreFoundation
+              CoreServices
+              Security
+              SystemConfiguration
+            ]);
+        };
+      in {
+        apps = {
+          default = self.apps.${system}.git-repo-manager;
+
+          git-repo-manager = flake-utils.lib.mkApp {
+            drv = self.packages.${system}.git-repo-manager;
+          };
+        };
+
+        devShells = {
+          default = pkgs.mkShell (environment
+            // {
+              buildInputs =
+                environment.buildInputs
+                ++ (with pkgs; [
+                  alejandra # nix formatting
+                  black
+                  isort
+                  just
+                  mdbook
+                  python3
+                  ruff
+                  shellcheck
+                  shfmt
+                ]);
+            });
+        };
+
+        packages = {
+          default = self.packages.${system}.git-repo-manager;
+
+          git-repo-manager = craneLib.buildPackage (environment
+            // {
+              cargoArtifacts = craneLib.buildDepsOnly environment;
+            });
+        };
+      }
+    );
+}

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -140,7 +140,7 @@ pub fn find_repo_paths(path: &Path) -> Result<Vec<PathBuf>, String> {
 }
 
 fn sync_repo(root_path: &Path, repo: &repo::Repo, init_worktree: bool) -> Result<(), String> {
-    let repo_path = root_path.join(&repo.fullname());
+    let repo_path = root_path.join(repo.fullname());
     let actual_git_directory = get_actual_git_directory(&repo_path, repo.worktree_setup);
 
     let mut newly_created = false;


### PR DESCRIPTION
I manage my system using [Nix](https://nixos.org)'s [home-manager](https://github.com/nix-community/home-manager), and I am adopting `git-repo-manager` to manage all of the Git repos I work with.

In this commit series I add support for:

- building and running `git-repo-manager` with Nix
- creating a build environment with all dependencies for `git-repo-manager` development
- importing `git-repo-manager` in other Nix builds (my personal use case)

I plan on continuing to use `git-repo-manager` personally, and in that case am also happy to maintain Nix support in this project.