### PR TITLE
Remove follows for crane flake input

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,6 @@
 
     crane = {
       url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
     };
     rust-overlay = {
       url = "github:oxalica/rust-overlay";


### PR DESCRIPTION
Crane has removed its dependence on nixpkgs, so using `follows` is is no longer required, and gives a warning.