### PR TITLE
nix: refactor/cleanup

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,28 +53,7 @@
       "inputs": {
         "crane": "crane",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1761878277,
-        "narHash": "sha256-6fCtyVdTzoQejwoextAu7dCLoy5fyD3WVh+Qm7t2Nhg=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "6604534e44090c917db714faa58d47861657690c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {

--- a/flake.lock
+++ b/flake.lock
@@ -35,16 +35,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1761468971,
-        "narHash": "sha256-vY2OLVg5ZTobdroQKQQSipSIkHlxOTrIF1fsMzPh8w8=",
+        "lastModified": 1761672384,
+        "narHash": "sha256-o9KF3DJL7g7iYMZq9SWgfS1BFlNbsm6xplRjVlOCkXI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "78e34d1667d32d8a0ffc3eba4591ff256e80576e",
+        "rev": "08dacfca559e1d7da38f3cf05f1f45ee9bfd213c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1761619008,
-        "narHash": "sha256-vp97eNmi5GG/+jlvnBpmG6EVO2F1+nqMQFF9GT2TIQg=",
+        "lastModified": 1761878277,
+        "narHash": "sha256-6fCtyVdTzoQejwoextAu7dCLoy5fyD3WVh+Qm7t2Nhg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7bc7d2f706ebe5479d230d2c6806b5dc757ae4cd",
+        "rev": "6604534e44090c917db714faa58d47861657690c",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,38 +1,5 @@
 {
   "nodes": {
-    "crane": {
-      "locked": {
-        "lastModified": 1760924934,
-        "narHash": "sha256-tuuqY5aU7cUkR71sO2TraVKK2boYrdW3gCSXUkF4i44=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "c6b4d5308293d0d04fcfeee92705017537cad02f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1761672384,
@@ -51,24 +18,7 @@
     },
     "root": {
       "inputs": {
-        "crane": "crane",
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,51 +3,57 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
-
-    crane = {
-      url = "github:ipetkov/crane";
-    };
   };
 
   outputs =
     {
       self,
       nixpkgs,
-      flake-utils,
-      crane,
     }:
+    let
+      inherit (nixpkgs) lib;
+      allSystems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      forAllSystems = function: lib.genAttrs allSystems (sys: function sys self.legacyPackages.${sys});
+    in
     {
       overlays = {
         git-repo-manager = final: prev: {
           git-repo-manager = self.packages.${prev.stdenv.system}.default;
         };
       };
-    }
-    // flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-        };
 
-        craneLib = crane.mkLib pkgs;
-      in
-      {
-        apps = {
+      legacyPackages = forAllSystems (system: _: import nixpkgs { inherit system; });
+
+      apps = forAllSystems (
+        system: _: {
           default = self.apps.${system}.git-repo-manager;
 
-          git-repo-manager = flake-utils.lib.mkApp {
-            drv = self.packages.${system}.git-repo-manager;
-          };
-        };
+          git-repo-manager =
+            let
+              inherit (self.packages.${system}) git-repo-manager;
+            in
+            {
+              type = "app";
+              inherit (git-repo-manager) meta;
+              program = lib.getExe git-repo-manager;
+            };
+        }
+      );
 
-        checks = {
+      checks = forAllSystems (
+        system: _: {
           pkg = self.packages.${system}.default;
           shl = self.devShells.${system}.default;
-        };
+        }
+      );
 
-        devShells = {
+      devShells = forAllSystems (
+        system: pkgs: {
           default = pkgs.mkShell {
             buildInputs = [
               self.packages.${pkgs.system}.default
@@ -64,14 +70,16 @@
               shfmt
             ]);
           };
-        };
+        }
+      );
 
-        packages = {
+      packages = forAllSystems (
+        system: pkgs: {
           default = self.packages.${system}.git-repo-manager;
 
           git-repo-manager = pkgs.rustPlatform.buildRustPackage {
             name = "grm"; # otherwise `nix run` looks for git-repo-manager
-            src = craneLib.cleanCargoSource (craneLib.path ./.);
+            src = ./.;
 
             cargoLock.lockFile = ./Cargo.lock;
 
@@ -86,7 +94,7 @@
             ];
             meta.mainProgram = "grm";
           };
-        };
-      }
-    );
+        }
+      );
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -92,7 +92,20 @@
               zlib
               zlib.dev
             ];
-            meta.mainProgram = "grm";
+            meta = {
+              description = "A git tool to manage worktrees and integrate with GitHub and GitLab";
+              longDescription = ''
+                GRM helps you manage git repositories in a declarative way. Configure your repositories in a TOML or YAML file, GRM does the rest.
+
+                Also, GRM can be used to work with git worktrees in an opinionated, straightforward fashion.
+              '';
+
+              homepage = "https://hakoerber.github.io/git-repo-manager/";
+              license = lib.licenses.gpl3Plus;
+              mainProgram = "grm";
+              maintainers = with lib.maintainers; [ siriobalmelli ];
+              platforms = lib.platforms.all;
+            };
           };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "git-repo-manager";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
 
     crane = {

--- a/flake.nix
+++ b/flake.nix
@@ -8,10 +8,6 @@
     crane = {
       url = "github:ipetkov/crane";
     };
-    rust-overlay = {
-      url = "github:oxalica/rust-overlay";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs =
@@ -20,7 +16,6 @@
       nixpkgs,
       flake-utils,
       crane,
-      rust-overlay,
     }:
     {
       overlays = {
@@ -34,29 +29,9 @@
       let
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [
-            rust-overlay.overlays.default
-          ];
         };
 
-        rustToolchain = pkgs.rust-bin.stable.latest.default;
-        craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
-
-        environment = with pkgs; {
-          pname = "grm"; # otherwise `nix run` looks for git-repo-manager
-          src = craneLib.cleanCargoSource (craneLib.path ./.);
-          buildInputs = [
-            # tools
-            pkg-config
-            rustToolchain
-            # deps
-            git
-            openssl
-            openssl.dev
-            zlib
-            zlib.dev
-          ];
-        };
+        craneLib = crane.mkLib pkgs;
       in
       {
         apps = {
@@ -73,32 +48,44 @@
         };
 
         devShells = {
-          default = pkgs.mkShell (
-            environment
-            // {
-              buildInputs =
-                environment.buildInputs
-                ++ (with pkgs; [
-                  black
-                  isort
-                  just
-                  mdbook
-                  nixfmt-classic # nix formatting
-                  python3
-                  ruff
-                  shellcheck
-                  shfmt
-                ]);
-            }
-          );
+          default = pkgs.mkShell {
+            buildInputs = [
+              self.packages.${pkgs.system}.default
+            ]
+            ++ (with pkgs; [
+              black
+              isort
+              just
+              mdbook
+              nixfmt-classic # nix formatting
+              python3
+              ruff
+              shellcheck
+              shfmt
+            ]);
+          };
         };
 
         packages = {
           default = self.packages.${system}.git-repo-manager;
 
-          git-repo-manager = craneLib.buildPackage (
-            environment // { cargoArtifacts = craneLib.buildDepsOnly environment; }
-          );
+          git-repo-manager = pkgs.rustPlatform.buildRustPackage {
+            name = "grm"; # otherwise `nix run` looks for git-repo-manager
+            src = craneLib.cleanCargoSource (craneLib.path ./.);
+
+            cargoLock.lockFile = ./Cargo.lock;
+
+            nativeBuildInputs = [ pkgs.pkg-config ];
+            buildInputs = with pkgs; [
+              # deps
+              git
+              openssl
+              openssl.dev
+              zlib
+              zlib.dev
+            ];
+            meta.mainProgram = "grm";
+          };
         };
       }
     );


### PR DESCRIPTION
Track upstream unstable instead of a release branch.

Remove unnecessary dependencies for faster evaluation.

Provide complete package metadata.

Inspired by https://github.com/hakoerber/git-repo-manager/pull/82, thank you @llakala