### PR TITLE
enable https and ssh features of git2 dependency to make clones work again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,7 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+ "openssl-probe",
  "openssl-sys",
  "url",
 ]
@@ -516,9 +517,24 @@ checksum = "1c42fe03df2bd3c53a3a9c7317ad91d80c81cd1fb0caec8d7cc4cd2bfa10c222"
 dependencies = [
  "cc",
  "libc",
+ "libssh2-sys",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -590,6 +606,12 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ features = ["derive"]
 [dependencies.git2]
 version = "=0.20.2"
 default-features = false
+features = ["https", "ssh"]
 
 [dependencies.shellexpand]
 version = "=3.1.1"


### PR DESCRIPTION
Clones are currently broken on develop. Enable `https` and `ssh` features of `git2` dependency to make them work again.  
Also see:
https://github.com/rust-lang/git2-rs?tab=readme-ov-file#features