### PR TITLE
Fix status for name with subdir

### DIFF
--- a/e2e_tests/helpers.py
+++ b/e2e_tests/helpers.py
@@ -337,11 +337,18 @@ class RepoTree:
                 [[trees.repos]]
                 name = "test_worktree"
                 worktree_setup = true
+
+                [[trees.repos]]
+                name = "test_namespace/test_nested"
             """)
 
         cmd = grm(["repos", "sync", "config", "--config", self.config.name])
         assert cmd.returncode == 0
-        return (self.root.name, self.config.name, ["test", "test_worktree"])
+        return (
+            self.root.name,
+            self.config.name,
+            ["test", "test_worktree", "test_namespace/test_nested"],
+        )
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         del self.root

--- a/e2e_tests/test_repos_status.py
+++ b/e2e_tests/test_repos_status.py
@@ -7,5 +7,6 @@ def test_repos_sync_worktree_clone():
     with RepoTree() as (root, config, repos):
         cmd = grm(["repos", "status", "--config", config])
         assert cmd.returncode == 0
+        assert "does not exist" not in cmd.stderr
         for repo in repos:
             assert repo in cmd.stdout

--- a/src/table.rs
+++ b/src/table.rs
@@ -194,12 +194,11 @@ pub fn get_status_table(trees: Vec<tree::Tree>) -> Result<(Vec<Table>, Vec<Error
         add_table_header(&mut table);
 
         for repo in &repos {
-            let repo_path = root_path.join(repo.name.as_str());
+            let repo_name = repo.fullname();
+            let repo_path = root_path.join(repo_name.as_str());
 
             if !repo_path.exists() {
-                errors.push(Error::RepoDoesNotExist {
-                    name: repo.name.clone(),
-                });
+                errors.push(Error::RepoDoesNotExist { name: repo_name });
                 continue;
             }
 
@@ -209,12 +208,10 @@ pub fn get_status_table(trees: Vec<tree::Tree>) -> Result<(Vec<Table>, Vec<Error
                 Ok(repo) => repo,
                 Err(error) => {
                     if matches!(error, repo::Error::RepoNotFound) {
-                        errors.push(Error::RepoNotGit {
-                            name: repo.name.clone(),
-                        });
+                        errors.push(Error::RepoNotGit { name: repo_name });
                     } else {
                         errors.push(Error::RepoOpenFailed {
-                            name: repo.name.clone(),
+                            name: repo_name,
                             message: error.to_string(),
                         });
                     }
@@ -224,12 +221,12 @@ pub fn get_status_table(trees: Vec<tree::Tree>) -> Result<(Vec<Table>, Vec<Error
 
             if let Err(err) = add_repo_status(
                 &mut table,
-                Some(&repo.name),
+                Some(&repo_name),
                 &repo_handle,
                 repo.worktree_setup,
             ) {
                 errors.push(Error::RepoStatusFailed {
-                    name: repo.name.clone(),
+                    name: repo_name,
                     message: err.to_string(),
                 });
             }


### PR DESCRIPTION
If you have a git repo at `~/code/dir/sub`, `grm repos find local ~/code` will correctly find the repo with name `dir/sub`. But then
```
grm repos status --config config.yml
╭──────┬──────────┬────────┬──────────┬──────┬─────────╮
│ Repo ┆ Worktree ┆ Status ┆ Branches ┆ HEAD ┆ Remotes │
╞══════╪══════════╪════════╪══════════╪══════╪═════════╡
╰──────┴──────────┴────────┴──────────┴──────┴─────────╯
[✘] Error: Repository "sub" does not exist. Run sync?
```
This PR fixes this.

Closes https://github.com/hakoerber/git-repo-manager/issues/89