### PR TITLE
Add --dirty flag

### DIFF
--- a/docs/src/local_configuration.md
+++ b/docs/src/local_configuration.md
@@ -70,8 +70,8 @@ $ grm repos status --config example.config.toml
 ```
 
 If you have a lot of repositories, the interesting ones are usually those that
-are not in sync with their remote. Use `--dirty` to hide all repositories that
-have neither uncommitted changes nor branches that are out of sync:
+hold something that is not backed up on a remote yet. Use `--dirty` to hide all
+repositories that are fully backed up:
 
 ```bash
 $ grm repos status --config example.config.toml --dirty
@@ -87,10 +87,15 @@ A repository is considered dirty when either of the following is true:
 
 * There are uncommitted changes in the working tree (new, modified or deleted
   files, including untracked ones).
-* There is a branch that is ahead of, behind or diverged from its remote
-  tracking branch.
+* There is a branch that is ahead of or diverged from its remote tracking
+  branch, so it holds commits that the remote does not have.
 * There is a branch that does not have a remote tracking branch at all, as it
   only exists locally.
+
+A branch that is merely *behind* its remote tracking branch does not make a
+repository dirty. Everything it holds is on the remote already, you are just
+missing something the remote has, which is a `git pull` and not a risk of losing
+work.
 
 Note that for repositories in a worktree setup, only the branches are taken into
 account, as those repositories do not have a working tree of their own.

--- a/docs/src/local_configuration.md
+++ b/docs/src/local_configuration.md
@@ -69,6 +69,32 @@ $ grm repos status --config example.config.toml
 ╰──────────────────┴──────────┴────────┴───────────────────┴────────┴─────────╯
 ```
 
+If you have a lot of repositories, the interesting ones are usually those that
+are not in sync with their remote. Use `--dirty` to hide all repositories that
+have neither uncommitted changes nor branches that are out of sync:
+
+```bash
+$ grm repos status --config example.config.toml --dirty
+╭──────────────────┬──────────┬─────────────┬──────────────────────┬────────┬─────────╮
+│ Repo             ┆ Worktree ┆ Status      ┆ Branches             ┆ HEAD   ┆ Remotes │
+╞══════════════════╪══════════╪═════════════╪══════════════════════╪════════╪═════════╡
+│ git-repo-manager ┆          ┆ Modified: 1 ┆ branch: master       ┆ master ┆ github  │
+│                  ┆          ┆             ┆ <origin/master> [+1] ┆        ┆ origin  │
+╰──────────────────┴──────────┴─────────────┴──────────────────────┴────────┴─────────╯
+```
+
+A repository is considered dirty when either of the following is true:
+
+* There are uncommitted changes in the working tree (new, modified or deleted
+  files, including untracked ones).
+* There is a branch that is ahead of, behind or diverged from its remote
+  tracking branch.
+* There is a branch that does not have a remote tracking branch at all, as it
+  only exists locally.
+
+Note that for repositories in a worktree setup, only the branches are taken into
+account, as those repositories do not have a working tree of their own.
+
 You can also use `status` without `--config` to check the repository you're
 currently in:
 

--- a/e2e_tests/test_repos_status.py
+++ b/e2e_tests/test_repos_status.py
@@ -1,4 +1,22 @@
-from helpers import RepoTree, grm, shell
+from helpers import EmptyDir, RepoTree, grm, shell
+
+
+def make_pushed_repo(root):
+    """
+    Create a repository in {root}/myrepo whose "master" branch tracks
+    origin/master and is fully pushed.
+    """
+    shell(f"""
+        cd {root}
+        git -c init.defaultBranch=master init --bare origin.git
+        git -c init.defaultBranch=master clone ./origin.git myrepo
+        cd myrepo
+        echo test > root-commit
+        git add root-commit
+        git commit -m "root-commit"
+        git push --set-upstream origin master
+    """)
+    return f"{root}/myrepo"
 
 
 def test_repos_sync_worktree_clone():
@@ -48,6 +66,43 @@ def test_repos_status_dirty_shows_repo_with_local_only_branch():
         assert "<!local>" in cmd.stdout
         assert "test_worktree" not in cmd.stdout
         assert "test_namespace/test_nested" not in cmd.stdout
+
+
+def test_repos_status_dirty_ignores_behind_branch():
+    with EmptyDir() as root:
+        repo_dir = make_pushed_repo(root)
+        shell(f"""
+            cd {repo_dir}
+            echo test > second-commit
+            git add second-commit
+            git commit -m "second-commit"
+            git push origin master
+            git reset --hard HEAD~1
+        """)
+
+        cmd = grm(["repos", "status"], cwd=repo_dir)
+        assert cmd.returncode == 0
+        assert "[-1]" in cmd.stdout
+
+        cmd = grm(["repos", "status", "--dirty"], cwd=repo_dir)
+        assert cmd.returncode == 0
+        assert "myrepo" not in cmd.stdout
+
+
+def test_repos_status_dirty_shows_ahead_branch():
+    with EmptyDir() as root:
+        repo_dir = make_pushed_repo(root)
+        shell(f"""
+            cd {repo_dir}
+            echo test > local-commit
+            git add local-commit
+            git commit -m "local-commit"
+        """)
+
+        cmd = grm(["repos", "status", "--dirty"], cwd=repo_dir)
+        assert cmd.returncode == 0
+        assert "myrepo" in cmd.stdout
+        assert "[+1]" in cmd.stdout
 
 
 def test_repos_status_dirty_single_repo():

--- a/e2e_tests/test_repos_status.py
+++ b/e2e_tests/test_repos_status.py
@@ -1,4 +1,4 @@
-from helpers import RepoTree, grm
+from helpers import RepoTree, grm, shell
 
 
 def test_repos_sync_worktree_clone():
@@ -8,3 +8,57 @@ def test_repos_sync_worktree_clone():
         assert "does not exist" not in cmd.stderr
         for repo in repos:
             assert repo in cmd.stdout
+
+
+def test_repos_status_dirty_hides_clean_repos():
+    with RepoTree() as (root, config, repos):
+        cmd = grm(["repos", "status", "--config", config, "--dirty"])
+        assert cmd.returncode == 0
+        assert "does not exist" not in cmd.stderr
+        for repo in repos:
+            assert repo not in cmd.stdout
+        assert cmd.stdout.strip() == ""
+
+
+def test_repos_status_dirty_shows_repo_with_uncommited_changes():
+    with RepoTree() as (root, config, repos):
+        shell(f"cd {root}/test && touch changed_file")
+
+        cmd = grm(["repos", "status", "--config", config, "--dirty"])
+        assert cmd.returncode == 0
+        assert "does not exist" not in cmd.stderr
+        assert "test" in cmd.stdout
+        assert "New: 1" in cmd.stdout
+        assert "test_worktree" not in cmd.stdout
+        assert "test_namespace/test_nested" not in cmd.stdout
+
+
+def test_repos_status_dirty_shows_repo_with_local_only_branch():
+    with RepoTree() as (root, config, repos):
+        shell(f"""
+            cd {root}/test
+            echo test > root-commit
+            git add root-commit
+            git commit -m "root-commit"
+        """)
+
+        cmd = grm(["repos", "status", "--config", config, "--dirty"])
+        assert cmd.returncode == 0
+        assert "does not exist" not in cmd.stderr
+        assert "<!local>" in cmd.stdout
+        assert "test_worktree" not in cmd.stdout
+        assert "test_namespace/test_nested" not in cmd.stdout
+
+
+def test_repos_status_dirty_single_repo():
+    with RepoTree() as (root, config, repos):
+        cmd = grm(["repos", "status", "--dirty"], cwd=f"{root}/test")
+        assert cmd.returncode == 0
+        assert "test" not in cmd.stdout
+
+        shell(f"cd {root}/test && touch changed_file")
+
+        cmd = grm(["repos", "status", "--dirty"], cwd=f"{root}/test")
+        assert cmd.returncode == 0
+        assert "test" in cmd.stdout
+        assert "New: 1" in cmd.stdout

--- a/src/grm/cmd.rs
+++ b/src/grm/cmd.rs
@@ -35,7 +35,7 @@ pub enum ReposAction {
     #[clap(subcommand)]
     Find(FindAction),
     #[clap(about = "Show status of configured repositories")]
-    Status(OptionalConfig),
+    Status(ReposStatusArgs),
 }
 
 #[derive(Parser)]
@@ -283,9 +283,15 @@ pub struct SyncRemoteArgs {
 
 #[derive(Parser)]
 #[clap()]
-pub struct OptionalConfig {
+pub struct ReposStatusArgs {
     #[clap(short, long, help = "Path to the configuration file")]
     pub config: Option<String>,
+
+    #[clap(
+        long = "dirty",
+        help = "Only show repositories with uncommitted changes or branches that are not up to date"
+    )]
+    pub dirty: bool,
 }
 
 #[derive(clap::ValueEnum, Clone)]

--- a/src/grm/cmd.rs
+++ b/src/grm/cmd.rs
@@ -289,7 +289,7 @@ pub struct ReposStatusArgs {
 
     #[clap(
         long = "dirty",
-        help = "Only show repositories with uncommitted changes or branches that are not up to date"
+        help = "Only show repositories that hold changes which are not backed up on a remote"
     )]
     pub dirty: bool,
 }

--- a/src/grm/main.rs
+++ b/src/grm/main.rs
@@ -394,7 +394,9 @@ fn handle_repos_sync(sync: cmd::SyncAction) -> HandlerResult {
     })
 }
 
-fn handle_repos_status(args: cmd::OptionalConfig) -> HandlerResult {
+fn handle_repos_status(args: cmd::ReposStatusArgs) -> HandlerResult {
+    let dirty_only = args.dirty;
+
     if let Some(config_path) = args.config {
         exec_with_result_channel(
             |config_path, tx| -> Result<(), MainError> {
@@ -403,8 +405,8 @@ fn handle_repos_status(args: cmd::OptionalConfig) -> HandlerResult {
                 let trees: Vec<tree::Tree> =
                     get_trees(config, tx).map_err(|e| MainError::GetTree(e))?;
 
-                let (tables, errors) =
-                    table::get_status_table(trees).map_err(|e| MainError::RepoStatus(e))?;
+                let (tables, errors) = table::get_status_table(trees, dirty_only)
+                    .map_err(|e| MainError::RepoStatus(e))?;
 
                 for table in tables {
                     println(&format!("{table}"));
@@ -428,8 +430,8 @@ fn handle_repos_status(args: cmd::OptionalConfig) -> HandlerResult {
     } else {
         let dir = path::current_dir()?;
 
-        let (table, warnings) =
-            table::show_single_repo_status(&dir).map_err(|e| MainError::RepoStatus(e))?;
+        let (table, warnings) = table::show_single_repo_status(&dir, dirty_only)
+            .map_err(|e| MainError::RepoStatus(e))?;
 
         println(&format!("{table}"));
         for warning in warnings {

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -360,19 +360,28 @@ impl RepoStatus {
         }
     }
 
-    /// Whether the repository holds any state that only exists locally, namely
-    /// uncommitted changes in the working tree or branches that are not up to
-    /// date with their remote tracking branch. Branches without a remote
-    /// tracking branch count as not up to date, as they only exist locally.
+    /// Whether the repository holds any state that only exists locally, i.e.
+    /// that is not backed up on a remote. That is the case for uncommitted
+    /// changes in the working tree, and for branches that have commits their
+    /// remote tracking branch does not have.
+    ///
+    /// A branch that is behind its remote tracking branch is *not* dirty, as
+    /// everything it holds is on the remote already. A branch without a remote
+    /// tracking branch is dirty, as it only exists locally.
     ///
     /// Note that this is not the negation of [`Self::clean()`], which only
     /// looks at the working tree.
     pub fn dirty(&self) -> bool {
         !self.clean()
-            || self
-                .branches
-                .iter()
-                .any(|branch| !matches!(branch.1, Some((_, RemoteTrackingStatus::UpToDate))))
+            || self.branches.iter().any(|branch| {
+                !matches!(
+                    branch.1,
+                    Some((
+                        _,
+                        RemoteTrackingStatus::UpToDate | RemoteTrackingStatus::Behind(_)
+                    ))
+                )
+            })
     }
 }
 

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -350,6 +350,7 @@ pub struct RepoStatus {
 }
 
 impl RepoStatus {
+    /// Whether the working tree has no uncommitted changes.
     fn clean(&self) -> bool {
         match self.changes {
             None => true,
@@ -357,6 +358,21 @@ impl RepoStatus {
                 changes.files_new == 0 && changes.files_deleted == 0 && changes.files_modified == 0
             }
         }
+    }
+
+    /// Whether the repository holds any state that only exists locally, namely
+    /// uncommitted changes in the working tree or branches that are not up to
+    /// date with their remote tracking branch. Branches without a remote
+    /// tracking branch count as not up to date, as they only exist locally.
+    ///
+    /// Note that this is not the negation of [`Self::clean()`], which only
+    /// looks at the working tree.
+    pub fn dirty(&self) -> bool {
+        !self.clean()
+            || self
+                .branches
+                .iter()
+                .any(|branch| !matches!(branch.1, Some((_, RemoteTrackingStatus::UpToDate))))
     }
 }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -57,11 +57,9 @@ fn add_table_header(table: &mut Table) {
 fn add_repo_status(
     table: &mut Table,
     repo_name: Option<&RepoName>,
-    repo_handle: &RepoHandle,
+    repo_status: repo::RepoStatus,
     worktree_setup: WorktreeSetup,
 ) -> Result<(), Error> {
-    let repo_status = repo_handle.status(worktree_setup).map_err(Error::Repo)?;
-
     let branch_info = {
         let mut acc = String::new();
         for (branch_name, remote_branch) in repo_status.branches {
@@ -180,7 +178,10 @@ pub fn get_worktree_status_table(
     Ok((table, errors))
 }
 
-pub fn get_status_table(trees: Vec<tree::Tree>) -> Result<(Vec<Table>, Vec<Error>), Error> {
+pub fn get_status_table(
+    trees: Vec<tree::Tree>,
+    dirty_only: bool,
+) -> Result<(Vec<Table>, Vec<Error>), Error> {
     let mut errors = Vec::new();
     let mut tables = Vec::new();
 
@@ -191,6 +192,7 @@ pub fn get_status_table(trees: Vec<tree::Tree>) -> Result<(Vec<Table>, Vec<Error
 
         let mut table = Table::new();
         add_table_header(&mut table);
+        let mut rows: usize = 0;
 
         for repo in &repos {
             let repo_name = repo.fullname();
@@ -218,20 +220,40 @@ pub fn get_status_table(trees: Vec<tree::Tree>) -> Result<(Vec<Table>, Vec<Error
                 }
             };
 
-            if let Err(err) = add_repo_status(
+            let repo_status = match repo_handle.status(repo.worktree_setup) {
+                Ok(repo_status) => repo_status,
+                Err(error) => {
+                    errors.push(Error::RepoStatusFailed {
+                        name: repo_name,
+                        message: error.to_string(),
+                    });
+                    continue;
+                }
+            };
+
+            if dirty_only && !repo_status.dirty() {
+                continue;
+            }
+
+            match add_repo_status(
                 &mut table,
                 Some(&repo_name),
-                &repo_handle,
+                repo_status,
                 repo.worktree_setup,
             ) {
-                errors.push(Error::RepoStatusFailed {
+                Ok(()) => rows = rows.saturating_add(1),
+                Err(err) => errors.push(Error::RepoStatusFailed {
                     name: repo_name,
                     message: err.to_string(),
-                });
+                }),
             }
         }
 
-        tables.push(table);
+        // Without any rows, the table would just be a header without any
+        // information, so skip it altogether when filtering.
+        if !dirty_only || rows > 0 {
+            tables.push(table);
+        }
     }
 
     Ok((tables, errors))
@@ -308,6 +330,7 @@ fn add_worktree_status(
 
 pub fn show_single_repo_status(
     path: &Path,
+    dirty_only: bool,
 ) -> Result<(impl std::fmt::Display, Vec<String>), Error> {
     let mut table = Table::new();
     let mut warnings = Vec::new();
@@ -335,12 +358,11 @@ pub fn show_single_repo_status(
         Some(file_name) => Some(RepoName::new(file_name.to_owned())),
     };
 
-    add_repo_status(
-        &mut table,
-        repo_name.as_ref(),
-        &repo_handle?,
-        worktree_setup,
-    )?;
+    let repo_status = repo_handle?.status(worktree_setup).map_err(Error::Repo)?;
+
+    if !dirty_only || repo_status.dirty() {
+        add_repo_status(&mut table, repo_name.as_ref(), repo_status, worktree_setup)?;
+    }
 
     Ok((table, warnings))
 }


### PR DESCRIPTION
I like to check whether all my repos are in sync. When there are many repos, having to skim through the whole table is harder than just filtering out the clean one and checking whether there are any left.
There is already the `clean` function but we might also want to check that the branches have matching remote ones.
In this PR, `--dirty` filters out the ones that are clean and for which all local branches have matching upstream ones in sync. I'm open to other name than `dirty` and other behavior, just let me know what you think.