### PR TITLE
Automatic set-upstream

### DIFF
--- a/docs/src/local_configuration.md
+++ b/docs/src/local_configuration.md
@@ -113,6 +113,50 @@ $ grm repos status
 ╰──────────┴──────────┴────────┴──────────┴───────┴─────────╯
 ```
 
+### Fix up missing tracking branches
+
+Branches that show up as `<!local>` do not have a remote tracking branch. This
+happens easily when pushing with plain `git push` instead of
+`git push --set-upstream`. To repair those in bulk, use `set-upstream`:
+
+```bash
+$ grm repos set-upstream --config example.config.toml
+[✔] git-repo-manager: Set upstream of "feature" to "origin/feature"
+[✔] dotfiles: Set upstream of "wip" to "origin/wip"
+```
+
+For every local branch that does not have a remote tracking branch, GRM looks
+for a branch of the same name on the remotes of that repository:
+
+* If exactly one remote has such a branch, it is set as the upstream.
+* If no remote has such a branch, the branch is left alone. It only exists
+  locally, so there is nothing to track.
+* If more than one remote has such a branch, there is no obvious candidate.
+  GRM refuses to guess, warns and exits with code 2.
+
+Branches that already have a remote tracking branch are never touched, so the
+command is safe to rerun.
+
+Note that GRM only looks at the refs that are already present locally, it does
+not contact the remotes. If a branch was pushed from another machine, fetch
+first, otherwise there is no `refs/remotes/<remote>/<branch>` for GRM to find.
+
+Just like `status`, `set-upstream` works on the repository you're currently in
+when used without `--config`:
+
+```bash
+$ cd ~/example-projects/dotfiles
+$ grm repos set-upstream
+[✔] dotfiles: Set upstream of "wip" to "origin/wip"
+```
+
+To prevent the problem in the first place, tell git to set the upstream on push
+automatically (requires git 2.37 or newer):
+
+```bash
+git config --global push.autoSetupRemote true
+```
+
 ## YAML
 
 By default, the repo configuration uses TOML. If you prefer YAML, just give it a

--- a/e2e_tests/test_repos_set_upstream.py
+++ b/e2e_tests/test_repos_set_upstream.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+import git
+from helpers import EmptyDir, grm, shell
+
+
+def make_repo(root):
+    """
+    Create a repository in {root}/repo with two branches:
+
+    * "master", which tracks origin/master
+    * "feature", which was pushed without --set-upstream, so origin/feature
+      exists, but the branch does not track anything
+    """
+    shell(f"""
+        cd {root}
+        git -c init.defaultBranch=master init --bare origin.git
+        git -c init.defaultBranch=master clone ./origin.git repo
+        cd repo
+        echo test > root-commit
+        git add root-commit
+        git commit -m "root-commit"
+        git push --set-upstream origin master
+        git switch --create feature
+        echo test > feature-commit
+        git add feature-commit
+        git commit -m "feature-commit"
+        git push origin feature
+    """)
+    return f"{root}/repo"
+
+
+def test_repos_set_upstream():
+    with EmptyDir() as root:
+        repo_dir = make_repo(root)
+        assert git.Repo(repo_dir).heads["feature"].tracking_branch() is None
+
+        cmd = grm(["repos", "set-upstream"], cwd=repo_dir)
+        assert cmd.returncode == 0
+        assert "feature" in cmd.stdout
+
+        repo = git.Repo(repo_dir)
+        assert repo.heads["feature"].tracking_branch().name == "origin/feature"
+        assert repo.heads["master"].tracking_branch().name == "origin/master"
+
+
+def test_repos_set_upstream_without_candidate():
+    with EmptyDir() as root:
+        repo_dir = make_repo(root)
+        shell(f"cd {repo_dir} && git switch --create local-only")
+
+        cmd = grm(["repos", "set-upstream"], cwd=repo_dir)
+        assert cmd.returncode == 0
+
+        repo = git.Repo(repo_dir)
+        assert repo.heads["local-only"].tracking_branch() is None
+        assert repo.heads["feature"].tracking_branch().name == "origin/feature"
+
+
+def test_repos_set_upstream_ambiguous():
+    with EmptyDir() as root:
+        repo_dir = make_repo(root)
+        shell(f"""
+            cd {root}
+            git -c init.defaultBranch=master init --bare other.git
+            cd repo
+            git remote add other file://{root}/other.git
+            git push other feature
+        """)
+
+        cmd = grm(["repos", "set-upstream"], cwd=repo_dir)
+        assert cmd.returncode == 2
+        assert "multiple remotes" in cmd.stderr
+
+        assert git.Repo(repo_dir).heads["feature"].tracking_branch() is None
+
+
+def test_repos_set_upstream_with_config():
+    with EmptyDir() as root:
+        repo_dir = make_repo(root)
+
+        config = f"{root}/config.toml"
+        with open(config, "w") as f:
+            f.write(f"""
+                [[trees]]
+                root = "{root}"
+
+                [[trees.repos]]
+                name = "repo"
+            """)
+
+        cmd = grm(["repos", "set-upstream", "--config", config])
+        assert cmd.returncode == 0
+
+        assert (
+            git.Repo(repo_dir).heads["feature"].tracking_branch().name
+            == "origin/feature"
+        )

--- a/src/grm/cmd.rs
+++ b/src/grm/cmd.rs
@@ -36,6 +36,8 @@ pub enum ReposAction {
     Find(FindAction),
     #[clap(about = "Show status of configured repositories")]
     Status(ReposStatusArgs),
+    #[clap(about = "Set the upstream of local branches that do not track a remote branch")]
+    SetUpstream(ReposSetUpstreamArgs),
 }
 
 #[derive(Parser)]
@@ -292,6 +294,13 @@ pub struct ReposStatusArgs {
         help = "Only show repositories that hold changes which are not backed up on a remote"
     )]
     pub dirty: bool,
+}
+
+#[derive(Parser)]
+#[clap()]
+pub struct ReposSetUpstreamArgs {
+    #[clap(short, long, help = "Path to the configuration file")]
+    pub config: Option<String>,
 }
 
 #[derive(clap::ValueEnum, Clone)]

--- a/src/grm/main.rs
+++ b/src/grm/main.rs
@@ -120,6 +120,10 @@ enum MainError {
     InvalidWorktreeName(repo::WorktreeValidationError),
     #[error("Failed guessing default branch")]
     WorktreeDefaultBranch(WorktreeError),
+    #[error("Failed setting upstream: {0}")]
+    SetUpstream(repo::Error),
+    #[error("There were failures while setting upstreams")]
+    SetUpstreamHasFailures,
 }
 
 impl MainError {
@@ -441,6 +445,123 @@ fn handle_repos_status(args: cmd::ReposStatusArgs) -> HandlerResult {
     Ok(MainExitCode::Success)
 }
 
+/// Set the upstream of all local branches of a single repository, reporting
+/// each change. Returns whether every branch had an unambiguous candidate.
+fn set_upstreams(repo_name: &str, repo_handle: &repo::RepoHandle) -> Result<bool, repo::Error> {
+    let mut unambiguous = true;
+
+    for (branch_name, detection) in repo_handle.set_missing_upstreams()? {
+        match detection {
+            repo::UpstreamDetection::Set(remote_name) => print_repo_success(
+                repo_name,
+                &format!("Set upstream of \"{branch_name}\" to \"{remote_name}/{branch_name}\""),
+            ),
+            repo::UpstreamDetection::Ambiguous(remote_names) => {
+                print_warning(format!(
+                    "{repo_name}: \"{branch_name}\" exists on multiple remotes ({}), skipping",
+                    remote_names
+                        .iter()
+                        .map(RemoteName::as_str)
+                        .collect::<Vec<&str>>()
+                        .join(", ")
+                ));
+                unambiguous = false;
+            }
+        }
+    }
+
+    Ok(unambiguous)
+}
+
+fn handle_repos_set_upstream(args: cmd::ReposSetUpstreamArgs) -> HandlerResult {
+    let (warnings, failures) = if let Some(config_path) = args.config {
+        exec_with_result_channel(
+            |config_path, tx| -> Result<(bool, bool), MainError> {
+                let config = read_config(&config_path)?;
+
+                let trees: Vec<tree::Tree> =
+                    get_trees(config, tx).map_err(|e| MainError::GetTree(e))?;
+
+                let mut warnings = false;
+                let mut failures = false;
+
+                for tree in trees {
+                    let root_path = path::expand_path(tree.root.as_path())?;
+
+                    for repo in &tree.repos {
+                        let repo_name = repo.fullname();
+                        let repo_path = root_path.join(repo_name.as_str());
+
+                        if !repo_path.exists() {
+                            print_repo_error(
+                                repo_name.as_str(),
+                                "Repository does not exist. Run sync?",
+                            );
+                            failures = true;
+                            continue;
+                        }
+
+                        let repo_handle = match repo::RepoHandle::open_with_worktree_setup(
+                            &repo_path,
+                            repo.worktree_setup,
+                        ) {
+                            Ok(repo_handle) => repo_handle,
+                            Err(error) => {
+                                print_repo_error(repo_name.as_str(), &error.to_string());
+                                failures = true;
+                                continue;
+                            }
+                        };
+
+                        match set_upstreams(repo_name.as_str(), &repo_handle) {
+                            Ok(true) => (),
+                            Ok(false) => warnings = true,
+                            Err(error) => {
+                                print_repo_error(repo_name.as_str(), &error.to_string());
+                                failures = true;
+                            }
+                        }
+                    }
+                }
+
+                Ok((warnings, failures))
+            },
+            |rx| {
+                for message in rx {
+                    match message {
+                        SyncTreesMessage::SyncTreeMessage(_) => unreachable!(),
+                        SyncTreesMessage::GetTreeWarning(warning) => print_warning(warning),
+                    }
+                }
+            },
+            config_path,
+        )?
+    } else {
+        let dir = get_cwd()?;
+        let worktree_setup = repo::WorktreeSetup::detect(&dir);
+
+        let repo_handle = repo::RepoHandle::open_with_worktree_setup(&dir, worktree_setup)
+            .map_err(|e| MainError::OpenRepo(e))?;
+
+        let repo_name = dir.file_name().unwrap_or(dir.as_str());
+
+        let unambiguous =
+            set_upstreams(repo_name, &repo_handle).map_err(|e| MainError::SetUpstream(e))?;
+
+        (!unambiguous, false)
+    };
+
+    if failures {
+        return Err(MainError::SetUpstreamHasFailures);
+    }
+
+    Ok(if warnings {
+        MainExitCode::Warnings
+    } else {
+        MainExitCode::Success
+    })
+}
+
 fn handle_repos_find_local(args: cmd::FindLocalArgs) -> HandlerResult {
     let path = Path::new(&args.path);
     if !path.exists() {
@@ -632,6 +753,7 @@ fn handle_repos(repos: cmd::Repos) -> HandlerResult {
     Ok(match repos.action {
         cmd::ReposAction::Sync(sync) => handle_repos_sync(sync)?,
         cmd::ReposAction::Status(args) => handle_repos_status(args)?,
+        cmd::ReposAction::SetUpstream(args) => handle_repos_set_upstream(args)?,
         cmd::ReposAction::Find(find) => handle_repos_find(find)?,
     })
 }

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -331,6 +331,17 @@ pub enum RemoteTrackingStatus {
     Diverged(usize, usize),
 }
 
+/// What happened to a local branch that does not have a remote tracking branch
+/// when looking for an obvious candidate.
+pub enum UpstreamDetection {
+    /// Exactly one remote has a branch with the same name, which was set as the
+    /// upstream of the local branch.
+    Set(RemoteName),
+    /// More than one remote has a branch with the same name, so there is no
+    /// obvious candidate. The local branch was left alone.
+    Ambiguous(Vec<RemoteName>),
+}
+
 pub struct RepoStatus {
     pub operation: Option<git2::RepositoryState>,
 
@@ -649,6 +660,46 @@ impl RepoHandle {
 
     pub fn create_branch(&self, name: &BranchName, target: &Commit) -> Result<Branch<'_>, Error> {
         Ok(Branch(self.0.branch(name.as_str(), &target.0, false)?))
+    }
+
+    /// Set the upstream of each local branch that does not have a remote
+    /// tracking branch yet to the branch of the same name on a remote, if
+    /// exactly one remote has such a branch.
+    ///
+    /// Branches that already have a remote tracking branch are never touched.
+    /// Note that only refs that are already present locally are taken into
+    /// account, so it may make sense to fetch beforehand.
+    ///
+    /// Returns the branches that were changed, together with the branches that
+    /// have more than one candidate and were therefore skipped. Branches
+    /// without any candidate are not returned.
+    pub fn set_missing_upstreams(&self) -> Result<Vec<(BranchName, UpstreamDetection)>, Error> {
+        let remotes = self.remotes()?;
+        let mut detections = Vec::new();
+
+        for mut branch in self.local_branches()? {
+            if branch.upstream()?.is_some() {
+                continue;
+            }
+
+            let branch_name = branch.name()?;
+
+            let mut candidates = Vec::new();
+            for remote in &remotes {
+                if self.find_remote_branch(remote, &branch_name)?.is_some() {
+                    candidates.push(remote.clone());
+                }
+            }
+
+            if candidates.len() > 1 {
+                detections.push((branch_name, UpstreamDetection::Ambiguous(candidates)));
+            } else if let Some(remote) = candidates.into_iter().next() {
+                branch.set_upstream(&remote, &branch_name)?;
+                detections.push((branch_name, UpstreamDetection::Set(remote)));
+            }
+        }
+
+        Ok(detections)
     }
 
     pub fn make_bare(&self, value: bool) -> Result<(), Error> {


### PR DESCRIPTION
I got a lot of `<!local>` branches which means many of my repos were considered `dirty` because I don't usually do `git push -u` and I did have the option `git config --global push.autoSetupRemote true`. So I implemented this for my own need. Now I have `autoSetupRemote` set to `true` and I matched the local branches of existing repo with the code of this PR so I shouldn't need it myself but I think it might be quite useful for other people in the same situation that I was.