### PR TITLE
Find unmanaged files

### DIFF
--- a/docs/src/local_configuration.md
+++ b/docs/src/local_configuration.md
@@ -157,6 +157,43 @@ automatically (requires git 2.37 or newer):
 git config --global push.autoSetupRemote true
 ```
 
+### Find files that are not in any repository
+
+A file that ended up next to your repositories instead of inside one of them is
+not backed up by anything. `unmanaged-files` walks each tree root and lists
+everything that is not part of a repository:
+
+```bash
+$ grm repos unmanaged-files --config example.config.toml
+/home/example/projects/docs
+/home/example/projects/notes.txt
+```
+
+Directories that do not contain any repository are reported as a whole, so a
+directory with a thousand files in it gives you one line, not a thousand. Once
+there is a repository somewhere below a directory, its remaining contents are
+listed one by one instead:
+
+```
+~/projects/
+├── git-repo-manager/     # a repository, skipped
+├── notes.txt             # reported
+├── docs/                 # reported as a whole, no repository below it
+│   └── draft.md
+└── nested/
+    ├── dotfiles/         # a repository, skipped
+    └── loose.txt         # reported, "nested" does contain a repository
+```
+
+The command exits with code 2 if it found anything, so it can be used as a
+check. Symlinks are never followed, as they could point outside of the tree.
+
+Without `--config`, the current directory is used as the root:
+
+```bash
+$ cd ~/projects && grm repos unmanaged-files
+```
+
 ## YAML
 
 By default, the repo configuration uses TOML. If you prefer YAML, just give it a

--- a/e2e_tests/test_repos_unmanaged_files.py
+++ b/e2e_tests/test_repos_unmanaged_files.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+from helpers import EmptyDir, grm, shell
+
+
+def test_repos_unmanaged_files():
+    with EmptyDir() as root:
+        shell(f"""
+            cd {root}
+            git -c init.defaultBranch=master init repo
+            touch stray.txt
+            mkdir -p docs/inner
+            touch docs/inner/draft.md
+            mkdir nested
+            git -c init.defaultBranch=master init nested/deep-repo
+            touch nested/loose.txt
+        """)
+
+        cmd = grm(["repos", "unmanaged-files"], cwd=root)
+        assert cmd.returncode == 2
+        assert cmd.stdout.splitlines() == [
+            f"{root}/docs",
+            f"{root}/nested/loose.txt",
+            f"{root}/stray.txt",
+        ]
+
+
+def test_repos_unmanaged_files_all_managed():
+    with EmptyDir() as root:
+        shell(f"""
+            cd {root}
+            git -c init.defaultBranch=master init repo
+            touch repo/tracked-later
+        """)
+
+        cmd = grm(["repos", "unmanaged-files"], cwd=root)
+        assert cmd.returncode == 0
+        assert cmd.stdout.strip() == ""
+
+
+def test_repos_unmanaged_files_root_is_repo():
+    with EmptyDir() as root:
+        shell(f"""
+            cd {root}
+            git -c init.defaultBranch=master init .
+            touch stray.txt
+        """)
+
+        cmd = grm(["repos", "unmanaged-files"], cwd=root)
+        assert cmd.returncode == 0
+        assert cmd.stdout.strip() == ""
+
+
+def test_repos_unmanaged_files_with_config():
+    with EmptyDir() as root:
+        shell(f"""
+            cd {root}
+            mkdir tree
+            cd tree
+            git -c init.defaultBranch=master init repo
+            touch stray.txt
+        """)
+
+        config = f"{root}/config.toml"
+        with open(config, "w") as f:
+            f.write(f"""
+                [[trees]]
+                root = "{root}/tree"
+
+                [[trees.repos]]
+                name = "repo"
+            """)
+
+        cmd = grm(["repos", "unmanaged-files", "--config", config])
+        assert cmd.returncode == 2
+        assert cmd.stdout.splitlines() == [f"{root}/tree/stray.txt"]

--- a/src/grm/cmd.rs
+++ b/src/grm/cmd.rs
@@ -38,6 +38,8 @@ pub enum ReposAction {
     Status(ReposStatusArgs),
     #[clap(about = "Set the upstream of local branches that do not track a remote branch")]
     SetUpstream(ReposSetUpstreamArgs),
+    #[clap(about = "List files that are not part of any repository")]
+    UnmanagedFiles(ReposUnmanagedFilesArgs),
 }
 
 #[derive(Parser)]
@@ -299,6 +301,13 @@ pub struct ReposStatusArgs {
 #[derive(Parser)]
 #[clap()]
 pub struct ReposSetUpstreamArgs {
+    #[clap(short, long, help = "Path to the configuration file")]
+    pub config: Option<String>,
+}
+
+#[derive(Parser)]
+#[clap()]
+pub struct ReposUnmanagedFilesArgs {
     #[clap(short, long, help = "Path to the configuration file")]
     pub config: Option<String>,
 }

--- a/src/grm/main.rs
+++ b/src/grm/main.rs
@@ -124,6 +124,8 @@ enum MainError {
     SetUpstream(repo::Error),
     #[error("There were failures while setting upstreams")]
     SetUpstreamHasFailures,
+    #[error("Failed finding unmanaged files: {0}")]
+    FindUnmanagedFiles(tree::Error),
 }
 
 impl MainError {
@@ -562,6 +564,53 @@ fn handle_repos_set_upstream(args: cmd::ReposSetUpstreamArgs) -> HandlerResult {
     })
 }
 
+fn handle_repos_unmanaged_files(args: cmd::ReposUnmanagedFilesArgs) -> HandlerResult {
+    let unmanaged = if let Some(config_path) = args.config {
+        exec_with_result_channel(
+            |config_path, tx| -> Result<Vec<PathBuf>, MainError> {
+                let config = read_config(&config_path)?;
+
+                let trees: Vec<tree::Tree> =
+                    get_trees(config, tx).map_err(|e| MainError::GetTree(e))?;
+
+                let mut unmanaged = Vec::new();
+
+                for tree in trees {
+                    let root_path = path::expand_path(tree.root.as_path())?;
+
+                    unmanaged.extend(
+                        tree::find_unmanaged_files(&root_path)
+                            .map_err(|e| MainError::FindUnmanagedFiles(e))?,
+                    );
+                }
+
+                Ok(unmanaged)
+            },
+            |rx| {
+                for message in rx {
+                    match message {
+                        SyncTreesMessage::SyncTreeMessage(_) => unreachable!(),
+                        SyncTreesMessage::GetTreeWarning(warning) => print_warning(warning),
+                    }
+                }
+            },
+            config_path,
+        )?
+    } else {
+        tree::find_unmanaged_files(&get_cwd()?).map_err(|e| MainError::FindUnmanagedFiles(e))?
+    };
+
+    for path in &unmanaged {
+        println(path.as_str());
+    }
+
+    Ok(if unmanaged.is_empty() {
+        MainExitCode::Success
+    } else {
+        MainExitCode::Warnings
+    })
+}
+
 fn handle_repos_find_local(args: cmd::FindLocalArgs) -> HandlerResult {
     let path = Path::new(&args.path);
     if !path.exists() {
@@ -754,6 +803,7 @@ fn handle_repos(repos: cmd::Repos) -> HandlerResult {
         cmd::ReposAction::Sync(sync) => handle_repos_sync(sync)?,
         cmd::ReposAction::Status(args) => handle_repos_status(args)?,
         cmd::ReposAction::SetUpstream(args) => handle_repos_set_upstream(args)?,
+        cmd::ReposAction::UnmanagedFiles(args) => handle_repos_unmanaged_files(args)?,
         cmd::ReposAction::Find(find) => handle_repos_find(find)?,
     })
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -209,14 +209,17 @@ pub fn sync_trees(
     ))
 }
 
+/// Whether the given directory is the root of a repository, either a normal one
+/// or one in a worktree setup.
+fn is_repo_root(path: &Path) -> bool {
+    path.join(".git").exists() || path.join(repo::GIT_MAIN_WORKTREE_DIRECTORY).exists()
+}
+
 /// Finds repositories recursively, returning their path
 pub fn find_repo_paths(path: &Path) -> Result<Vec<PathBuf>, Error> {
     let mut repos = Vec::new();
 
-    let git_dir = path.join(".git");
-    let git_worktree = path.join(repo::GIT_MAIN_WORKTREE_DIRECTORY);
-
-    if git_dir.exists() || git_worktree.exists() {
+    if is_repo_root(path) {
         repos.push(path.to_path_buf());
     } else {
         match fs::read_dir(path) {
@@ -258,6 +261,75 @@ pub fn find_repo_paths(path: &Path) -> Result<Vec<PathBuf>, Error> {
     }
 
     Ok(repos)
+}
+
+/// Collect everything under `path` that is not part of any repository, assuming
+/// that the contents of `path` have to be listed one by one.
+///
+/// Returns whether there is a repository somewhere below `path`, together with
+/// the paths that are not part of a repository. A directory that does not
+/// contain any repository is reported as a whole instead of each of its
+/// contents separately, as reporting a single directory is a lot more useful
+/// than reporting each file inside of it.
+///
+/// Symlinks are never followed. They are reported like normal files, as
+/// following them could lead outside of the tree.
+fn find_unmanaged_files_in(path: &Path) -> Result<(bool, Vec<PathBuf>), Error> {
+    if is_repo_root(path) {
+        return Ok((true, Vec::new()));
+    }
+
+    let contents = match fs::read_dir(path) {
+        Ok(contents) => contents,
+        Err(e) => {
+            return Err(match e.kind() {
+                std::io::ErrorKind::NotFound => Error::NotFound {
+                    path: path.to_path_buf(),
+                },
+                kind => Error::Open {
+                    path: path.to_path_buf(),
+                    kind,
+                },
+            });
+        }
+    };
+
+    let mut contains_repo = false;
+    let mut unmanaged = Vec::new();
+
+    for content in contents {
+        let entry = content.map_err(|e| Error::DirectoryAccess {
+            message: e.to_string(),
+        })?;
+        let entry_path = path::from_std_path_buf(entry.path())?;
+
+        if entry_path.is_dir() && !entry_path.is_symlink() {
+            let (sub_contains_repo, sub_unmanaged) = find_unmanaged_files_in(&entry_path)?;
+            if sub_contains_repo {
+                contains_repo = true;
+                unmanaged.extend(sub_unmanaged);
+            } else {
+                unmanaged.push(entry_path);
+            }
+        } else {
+            unmanaged.push(entry_path);
+        }
+    }
+
+    Ok((contains_repo, unmanaged))
+}
+
+/// Find all paths under `root_path` that are not part of any repository.
+///
+/// If `root_path` itself is a repository, nothing is reported. If it does not
+/// contain any repository at all, its contents are reported, as reporting the
+/// root itself would not tell the user anything they did not already know.
+pub fn find_unmanaged_files(root_path: &Path) -> Result<Vec<PathBuf>, Error> {
+    let (_contains_repo, mut unmanaged) = find_unmanaged_files_in(root_path)?;
+
+    unmanaged.sort();
+
+    Ok(unmanaged)
 }
 
 fn sync_repo(


### PR DESCRIPTION
I have some folders that I don't backup because I assume everything inside is in git remotes anyway. This is where `git-repo-manager` is very useful, especially with the `--dirty` flag since it allows me to check that everything is indeed backed up. The only missing piece for complete piece of mind is to check that there are no files that are just outside git repos so `grm repos sync` just ignored them. This PR completes this last part.